### PR TITLE
Replace smart quotes

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -4,7 +4,7 @@
 target "ImgurSessionOSX", :exclusive => true do
 
 platform :osx, "10.9"
-pod 'AFNetworking', '~> 3.1.0’
+pod 'AFNetworking', '~> 3.1.0'
 
 end
 
@@ -43,7 +43,7 @@ end
 target "ImgurSession", :exclusive => true do
 
 platform :ios, "8.0"
-pod 'AFNetworking', '~> 3.1.0’
+pod 'AFNetworking', '~> 3.1.0'
 
 end
 


### PR DESCRIPTION
Replace the smart quotes introduced in 94beaa210bd5dd18b5ad8e67e403ebbe150daba9.

This fixes the following CocoaPods warning:

> [!] Your Podfile has had smart quotes sanitised. To avoid issues in the future, you should not use TextEdit for editing it. If you are not using TextEdit, you should turn off smart quotes in your editor of choice.
