### PR TITLE
Update podspec AFNetworking version

### DIFF
--- a/ImgurSession.podspec
+++ b/ImgurSession.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |spec|
   spec.source_files     = 'ImgurSession/**/*.{h,m}'
   spec.author              = { "Geoff MacDonald" => "geoffmacd@gmail.com" }
   spec.framework        = 'Foundation'
-  spec.dependency 'AFNetworking', '2.6.3'
+  spec.dependency 'AFNetworking', '3.1.0'
   spec.ios.deployment_target = '8.0'
   spec.osx.deployment_target = "10.9"
   spec.requires_arc     = true


### PR DESCRIPTION
This updates the version of AFNetworking specified in the podspec to be the same as the one specified in the Podfile.

This resolves the following error:

`ImgurSession/Requests/IMGImageRequest.m:240:34: No visible @interface for 'IMGSession' declares the selector 'POST:parameters:constructingBodyWithBlock:progress:success:failure:'`
